### PR TITLE
#feat(api) : add brand resource update endpoint

### DIFF
--- a/TypeScript/Typescript Final Project/src/controllers/brand/update-brand.controller.ts
+++ b/TypeScript/Typescript Final Project/src/controllers/brand/update-brand.controller.ts
@@ -1,0 +1,26 @@
+import { NextFunction, Request, Response } from 'express';
+import BrandInterface from '../../interfaces/brand/model-interfcaes/brand.interface.js';
+import updateBrandService from '../../services/brand/update-brand.service.js';
+import SuccessApiResponse from '../../utils/api-response/success-api-response.utils.js';
+
+const updateBrandController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const id: string = req.brand?.id;
+    const data: BrandInterface = req.body;
+    const updatedData = await updateBrandService(id, data);
+    new SuccessApiResponse(
+      200,
+      'Resource Update Successful',
+      updatedData
+    ).sendSuccessResponse(res);
+    return;
+  } catch (error) {
+    next(error);
+  }
+};
+
+export default updateBrandController;

--- a/TypeScript/Typescript Final Project/src/middlewares/brand/get-brand-by-id.middleware.ts
+++ b/TypeScript/Typescript Final Project/src/middlewares/brand/get-brand-by-id.middleware.ts
@@ -11,16 +11,17 @@ const getBrandByIdMiddleware = async (
   try {
     const id = req.params.id;
     const brand = await findBrandByIdRepositories(id);
-    if (brand) {
-      req.brand = brand;
-      next();
+    if (!brand) {
+      new ErrorApiResponse(
+        404,
+        'Resource Not Found',
+        `Brand With This Id : ${id} Not found!`,
+        'Please Provide A Valid Brand Id'
+      ).sendErrorResponse(res);
+      return;
     }
-    new ErrorApiResponse(
-      404,
-      'Resource Not Found',
-      `Brand With This Id : ${id} Not found!`,
-      'Please Provide A Valid Brand Id'
-    ).sendErrorResponse(res);
+    req.brand = brand;
+    next();
   } catch (error) {
     next(error);
   }

--- a/TypeScript/Typescript Final Project/src/repositories/brand/update-brand.repository.ts
+++ b/TypeScript/Typescript Final Project/src/repositories/brand/update-brand.repository.ts
@@ -1,0 +1,22 @@
+import { Document } from 'mongoose';
+import BrandInterface from '../../interfaces/brand/model-interfcaes/brand.interface.js';
+import Brand from '../../models/brand.model.js';
+
+const updateBrandRepository = async (
+  id: string,
+  data: BrandInterface
+): Promise<Document | null> => {
+  try {
+    const updatedData = await Brand.findByIdAndUpdate(
+      id,
+      { $set: data },
+      { new: true }
+    );
+    return updatedData;
+  } catch (error) {
+    if (error instanceof Error) throw new Error(error.message);
+    throw new Error('An unknown error occurred in isBrandExistRepository.');
+  }
+};
+
+export default updateBrandRepository;

--- a/TypeScript/Typescript Final Project/src/routes/brand.routes.ts
+++ b/TypeScript/Typescript Final Project/src/routes/brand.routes.ts
@@ -14,6 +14,7 @@ import isBrandExistMiddleware from '../middlewares/brand/is-brand-exist.middlewa
 import getBrandsController from '../controllers/brand/get-brands.controller.js';
 import getBrandByIdMiddleware from '../middlewares/brand/get-brand-by-id.middleware.js';
 import getBrandByIdController from '../controllers/brand/get-brand-by-id.controller.js';
+import updateBrandController from '../controllers/brand/update-brand.controller.js';
 
 router
   .route('/brand')
@@ -24,5 +25,13 @@ router
   )
   .get(getBrandsController);
 
-router.route(`/brand/:id`).get(getBrandByIdMiddleware, getBrandByIdController);
+router
+  .route(`/brand/:id`)
+  .get(getBrandByIdMiddleware, getBrandByIdController)
+  .put(
+    getBrandByIdMiddleware,
+    brandInputValidationMiddleware,
+    updateBrandController
+  )
+  .delete();
 export default router;

--- a/TypeScript/Typescript Final Project/src/services/brand/update-brand.service.ts
+++ b/TypeScript/Typescript Final Project/src/services/brand/update-brand.service.ts
@@ -1,0 +1,19 @@
+import { Document } from 'mongoose';
+import BrandInterface from '../../interfaces/brand/model-interfcaes/brand.interface.js';
+import updateBrandRepository from '../../repositories/brand/update-brand.repository.js';
+
+const updateBrandService = async (
+  id: string,
+  data: BrandInterface
+): Promise<Document> => {
+  try {
+    const updatedData = await updateBrandRepository(id, data);
+    if (!updatedData) throw new Error('Internal Server Error');
+    return updatedData;
+  } catch (error) {
+    if (error instanceof Error) throw new Error(error.message);
+    throw new Error('An unknown error occurred in isBrandExistRepository.');
+  }
+};
+
+export default updateBrandService;


### PR DESCRIPTION
Implemented a new API endpoint to handle the full update of brand resources.
The endpoint allows clients to update the details of an existing brand resource.
It ensures the resource is fully replaced with the provided data, supporting all necessary fields for brand updates.