### PR TITLE
#feat(api) : added brand delete endpoint

### DIFF
--- a/TypeScript/Typescript Final Project/src/controllers/brand/delete-brand.controller.ts
+++ b/TypeScript/Typescript Final Project/src/controllers/brand/delete-brand.controller.ts
@@ -1,0 +1,23 @@
+import { NextFunction, Request, Response } from 'express';
+import deleteBrandService from '../../services/brand/delete-brand.service.js';
+import SuccessApiResponse from '../../utils/api-response/success-api-response.utils.js';
+
+const deleteBrandController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const id = req.brand?.id;
+    await deleteBrandService(id);
+    new SuccessApiResponse(
+      200,
+      'Resource Deleted Successful'
+    ).sendSuccessResponse(res);
+    return;
+  } catch (error) {
+    next(error);
+  }
+};
+
+export default deleteBrandController;

--- a/TypeScript/Typescript Final Project/src/controllers/brand/get-brands.controller.ts
+++ b/TypeScript/Typescript Final Project/src/controllers/brand/get-brands.controller.ts
@@ -9,11 +9,18 @@ const getBrandsController = async (
 ): Promise<void> => {
   try {
     const data = await getBrandsService();
+    if (data.length === 0) {
+      new SuccessApiResponse(200, 'No Brands Found', data).sendSuccessResponse(
+        res
+      );
+      return;
+    }
     new SuccessApiResponse(
       200,
       'Brands Retrieve Successful',
       data
     ).sendSuccessResponse(res);
+    return;
   } catch (error) {
     console.log(error);
     next(error);

--- a/TypeScript/Typescript Final Project/src/repositories/brand/delete-brand.repository.ts
+++ b/TypeScript/Typescript Final Project/src/repositories/brand/delete-brand.repository.ts
@@ -1,0 +1,17 @@
+import { ObjectId } from 'mongoose';
+import Brand from '../../models/brand.model.js';
+
+const deleteBrandRepository = async (
+  id: string | ObjectId
+): Promise<boolean> => {
+  try {
+    const responseData = await Brand.findByIdAndDelete(id);
+    if (!responseData) return false;
+    return true;
+  } catch (error) {
+    if (error instanceof Error) throw new Error(error.message);
+    throw new Error('An unknown error occurred in isBrandExistRepository.');
+  }
+};
+
+export default deleteBrandRepository;

--- a/TypeScript/Typescript Final Project/src/routes/brand.routes.ts
+++ b/TypeScript/Typescript Final Project/src/routes/brand.routes.ts
@@ -15,6 +15,7 @@ import getBrandsController from '../controllers/brand/get-brands.controller.js';
 import getBrandByIdMiddleware from '../middlewares/brand/get-brand-by-id.middleware.js';
 import getBrandByIdController from '../controllers/brand/get-brand-by-id.controller.js';
 import updateBrandController from '../controllers/brand/update-brand.controller.js';
+import deleteBrandController from '../controllers/brand/delete-brand.controller.js';
 
 router
   .route('/brand')
@@ -33,5 +34,5 @@ router
     brandInputValidationMiddleware,
     updateBrandController
   )
-  .delete();
+  .delete(getBrandByIdMiddleware, deleteBrandController);
 export default router;

--- a/TypeScript/Typescript Final Project/src/services/brand/delete-brand.service.ts
+++ b/TypeScript/Typescript Final Project/src/services/brand/delete-brand.service.ts
@@ -1,0 +1,15 @@
+import { ObjectId } from 'mongoose';
+import deleteBrandRepository from '../../repositories/brand/delete-brand.repository.js';
+
+const deleteBrandService = async (id: string | ObjectId): Promise<boolean> => {
+  try {
+    const response = await deleteBrandRepository(id);
+    if (!response) throw new Error('Internal Server Error');
+    return response;
+  } catch (error) {
+    if (error instanceof Error) throw new Error(error.message);
+    throw new Error('An unknown error occurred in isBrandExistRepository.');
+  }
+};
+
+export default deleteBrandService;


### PR DESCRIPTION
This PR introduces a new feature to the API by adding a DELETE endpoint for deleting brands. The endpoint allows users to remove a brand from the system by providing its unique identifier (ID). Upon successful deletion, the API responds with a success message indicating the brand was removed. If the brand does not exist, a detailed error message is returned to notify the user. This addition enhances the API's functionality, enabling full CRUD (Create, Read, Update, Delete) operations for managing brands.