### PR TITLE
#feat(api) : category create/get all/get one/update/delete endpoints added

### DIFF
--- a/TypeScript/Typescript Final Project/src/controllers/category/create-category.controller.ts
+++ b/TypeScript/Typescript Final Project/src/controllers/category/create-category.controller.ts
@@ -1,0 +1,23 @@
+import { NextFunction, Request, Response } from 'express';
+import createCategoryService from '../../services/category/create-category.service.js';
+import SuccessApiResponse from '../../utils/api-response/success-api-response.utils.js';
+
+const createCategoryController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const data = await createCategoryService(req.body);
+    new SuccessApiResponse(
+      201,
+      'New Category Created',
+      data
+    ).sendSuccessResponse(res);
+    return;
+  } catch (error) {
+    next(error);
+  }
+};
+
+export default createCategoryController;

--- a/TypeScript/Typescript Final Project/src/controllers/category/delete-category.controller.ts
+++ b/TypeScript/Typescript Final Project/src/controllers/category/delete-category.controller.ts
@@ -1,0 +1,22 @@
+import { NextFunction, Request, Response } from 'express';
+import deleteCategoryService from '../../services/category/delete-category.service.js';
+import SuccessApiResponse from '../../utils/api-response/success-api-response.utils.js';
+
+const deleteCategoryController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const id = req.category?.id;
+    await deleteCategoryService(id);
+    new SuccessApiResponse(
+      200,
+      'Resource Deleted Successful'
+    ).sendSuccessResponse(res);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export default deleteCategoryController;

--- a/TypeScript/Typescript Final Project/src/controllers/category/get-all-category.controller.ts
+++ b/TypeScript/Typescript Final Project/src/controllers/category/get-all-category.controller.ts
@@ -1,0 +1,23 @@
+import { NextFunction, Request, Response } from 'express';
+import getAllCategoriesService from '../../services/category/get-all-category.service.js';
+import SuccessApiResponse from '../../utils/api-response/success-api-response.utils.js';
+
+const getAllCategoriesController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const data = await getAllCategoriesService();
+    new SuccessApiResponse(
+      200,
+      'Retrieve All Categories Successful',
+      data
+    ).sendSuccessResponse(res);
+    return;
+  } catch (error) {
+    next(error);
+  }
+};
+
+export default getAllCategoriesController;

--- a/TypeScript/Typescript Final Project/src/controllers/category/get-category-by-id.controller.ts
+++ b/TypeScript/Typescript Final Project/src/controllers/category/get-category-by-id.controller.ts
@@ -1,0 +1,22 @@
+import { NextFunction, Request, Response } from 'express';
+import SuccessApiResponse from '../../utils/api-response/success-api-response.utils.js';
+
+const getCategoryByIdController = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const data = req.category;
+    new SuccessApiResponse(
+      200,
+      'Category Retrieve Successful',
+      data
+    ).sendSuccessResponse(res);
+    return;
+  } catch (error) {
+    next(error);
+  }
+};
+
+export default getCategoryByIdController;

--- a/TypeScript/Typescript Final Project/src/controllers/category/update-category.controller.ts
+++ b/TypeScript/Typescript Final Project/src/controllers/category/update-category.controller.ts
@@ -1,0 +1,25 @@
+import { NextFunction, Request, Response } from 'express';
+import updateCategoryService from '../../services/category/update-category.service.js';
+import SuccessApiResponse from '../../utils/api-response/success-api-response.utils.js';
+
+const updateCategoryController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const id = req.category?.id;
+    const data = req.body;
+    const response = await updateCategoryService(id, data);
+    new SuccessApiResponse(
+      200,
+      'Category Updated Successful',
+      response
+    ).sendSuccessResponse(res);
+    return;
+  } catch (error) {
+    next(error);
+  }
+};
+
+export default updateCategoryController;

--- a/TypeScript/Typescript Final Project/src/middlewares/category/find-category-by-id.middleware.ts
+++ b/TypeScript/Typescript Final Project/src/middlewares/category/find-category-by-id.middleware.ts
@@ -1,0 +1,29 @@
+import { NextFunction, Request, Response } from 'express';
+import findCategoryByIdRepository from '../../repositories/category/find-category-by-id.repository.js';
+import ErrorApiResponse from '../../utils/api-response/base-error-api-response.utils.js';
+
+const findCategoryByIdMiddleware = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const data = await findCategoryByIdRepository(id);
+    if (!data) {
+      new ErrorApiResponse(
+        404,
+        'Not Found',
+        `Category With This Id : ${id} Not Found`,
+        'Please Give Valid Id'
+      ).sendErrorResponse(res);
+      return;
+    }
+    req.category = data;
+    next();
+  } catch (error) {
+    next(error);
+  }
+};
+
+export default findCategoryByIdMiddleware;

--- a/TypeScript/Typescript Final Project/src/repositories/brand/get-brands.repository.ts
+++ b/TypeScript/Typescript Final Project/src/repositories/brand/get-brands.repository.ts
@@ -3,7 +3,7 @@ import Brand from '../../models/brand.model.js';
 
 const getBrandsRepository = async (): Promise<Document[]> => {
   try {
-    const data = await Brand.find();
+    const data = await Brand.find({});
     return data;
   } catch (error) {
     if (error instanceof Error) throw new Error(error.message);

--- a/TypeScript/Typescript Final Project/src/repositories/category/dalate-category.repository.ts
+++ b/TypeScript/Typescript Final Project/src/repositories/category/dalate-category.repository.ts
@@ -1,0 +1,15 @@
+import Category from '../../models/category.model.js';
+import handleRepositoryError from '../../utils/errors/handle-repository-error.util.js';
+
+const deleteCategoryRepository = async (id: string): Promise<boolean> => {
+  try {
+    const response = await Category.findByIdAndDelete(id);
+    if (!response) return false;
+    return true;
+  } catch (error) {
+    handleRepositoryError(error);
+    return false;
+  }
+};
+
+export default deleteCategoryRepository;

--- a/TypeScript/Typescript Final Project/src/repositories/category/find-category-by-id.repository.ts
+++ b/TypeScript/Typescript Final Project/src/repositories/category/find-category-by-id.repository.ts
@@ -1,0 +1,17 @@
+import { Document } from 'mongoose';
+import Category from '../../models/category.model.js';
+import handleRepositoryError from '../../utils/errors/handle-repository-error.util.js';
+
+const findCategoryByIdRepository = async (
+  id: string
+): Promise<Document | null> => {
+  try {
+    const data = await Category.findById(id);
+    return data;
+  } catch (error) {
+    handleRepositoryError(error);
+    return null;
+  }
+};
+
+export default findCategoryByIdRepository;

--- a/TypeScript/Typescript Final Project/src/repositories/category/get-all-categories.repository.ts
+++ b/TypeScript/Typescript Final Project/src/repositories/category/get-all-categories.repository.ts
@@ -1,0 +1,15 @@
+import { Document } from 'mongoose';
+import Category from '../../models/category.model.js';
+import handleRepositoryError from '../../utils/errors/handle-repository-error.util.js';
+
+const getAllCategoriesRepository = async (): Promise<Document[]> => {
+  try {
+    const data = await Category.find({});
+    return data;
+  } catch (error) {
+    handleRepositoryError(error);
+    return [];
+  }
+};
+
+export default getAllCategoriesRepository;

--- a/TypeScript/Typescript Final Project/src/repositories/category/update-category.repository.ts
+++ b/TypeScript/Typescript Final Project/src/repositories/category/update-category.repository.ts
@@ -1,0 +1,25 @@
+import { Document } from 'mongoose';
+import CategoryInterface from '../../interfaces/category/category.interface.js';
+import handleRepositoryError from '../../utils/errors/handle-repository-error.util.js';
+import Category from '../../models/category.model.js';
+
+const updateCategoryRepository = async (
+  id: string,
+  data: CategoryInterface
+): Promise<Document | null> => {
+  try {
+    const response = await Category.findByIdAndUpdate(
+      id,
+      {
+        $set: data,
+      },
+      { new: true }
+    );
+    return response;
+  } catch (error) {
+    handleRepositoryError(error);
+    return null;
+  }
+};
+
+export default updateCategoryRepository;

--- a/TypeScript/Typescript Final Project/src/routes/category.routes.ts
+++ b/TypeScript/Typescript Final Project/src/routes/category.routes.ts
@@ -7,16 +7,34 @@ const router = Router();
 =====================================================*/
 import categoryInputValidationMiddleware from '../middlewares/category/category-input-validation.middleware.js';
 import isCategoryExistMiddleware from '../middlewares/category/is-category-exist.middleware.js';
+import findCategoryByIdMiddleware from '../middlewares/category/find-category-by-id.middleware.js';
 
 /* ===================================================
 -----------------------CONTROLLERS--------------------
 =====================================================*/
+import createCategoryController from '../controllers/category/create-category.controller.js';
+import getAllCategoriesController from '../controllers/category/get-all-category.controller.js';
+import getCategoryByIdController from '../controllers/category/get-category-by-id.controller.js';
+import updateCategoryController from '../controllers/category/update-category.controller.js';
+import deleteCategoryController from '../controllers/category/delete-category.controller.js';
 
 router
   .route('/categories')
-  .post(categoryInputValidationMiddleware, isCategoryExistMiddleware)
-  .get();
+  .post(
+    categoryInputValidationMiddleware,
+    isCategoryExistMiddleware,
+    createCategoryController
+  )
+  .get(getAllCategoriesController);
 
-router.route('/categories/:id').get().put().delete();
+router
+  .route('/categories/:id')
+  .get(findCategoryByIdMiddleware, getCategoryByIdController)
+  .put(
+    findCategoryByIdMiddleware,
+    categoryInputValidationMiddleware,
+    updateCategoryController
+  )
+  .delete(findCategoryByIdMiddleware, deleteCategoryController);
 
 export default router;

--- a/TypeScript/Typescript Final Project/src/services/category/create-category.service.ts
+++ b/TypeScript/Typescript Final Project/src/services/category/create-category.service.ts
@@ -10,7 +10,7 @@ const createCategoryService = async (
     return createdCategory;
   } catch (error) {
     if (error instanceof Error) throw new Error(error.message);
-    throw new Error('Unknown Error Occurred');
+    throw new Error('An unknown error occurred in isBrandExistRepository.');
   }
 };
 

--- a/TypeScript/Typescript Final Project/src/services/category/delete-category.service.ts
+++ b/TypeScript/Typescript Final Project/src/services/category/delete-category.service.ts
@@ -1,0 +1,15 @@
+import deleteCategoryRepository from '../../repositories/category/dalate-category.repository.js';
+import handleServiceError from '../../utils/errors/handle-service-error.utils.js';
+
+const deleteCategoryService = async (id: string): Promise<boolean> => {
+  try {
+    const response = await deleteCategoryRepository(id);
+    if (!response) throw new Error('Internal Server Error');
+    return response;
+  } catch (error) {
+    handleServiceError(error);
+    return false;
+  }
+};
+
+export default deleteCategoryService;

--- a/TypeScript/Typescript Final Project/src/services/category/get-all-category.service.ts
+++ b/TypeScript/Typescript Final Project/src/services/category/get-all-category.service.ts
@@ -1,0 +1,15 @@
+import { Document } from 'mongoose';
+import handleServiceError from '../../utils/errors/handle-service-error.utils.js';
+import getAllCategoriesRepository from '../../repositories/category/get-all-categories.repository.js';
+
+const getAllCategoriesService = async (): Promise<Document[]> => {
+  try {
+    const data = await getAllCategoriesRepository();
+    return data;
+  } catch (error) {
+    handleServiceError(error);
+    return [];
+  }
+};
+
+export default getAllCategoriesService;

--- a/TypeScript/Typescript Final Project/src/services/category/update-category.service.ts
+++ b/TypeScript/Typescript Final Project/src/services/category/update-category.service.ts
@@ -1,0 +1,20 @@
+import { Document } from 'mongoose';
+import CategoryInterface from '../../interfaces/category/category.interface.js';
+import handleServiceError from '../../utils/errors/handle-service-error.utils.js';
+import updateCategoryRepository from '../../repositories/category/update-category.repository.js';
+
+const updateCategoryService = async (
+  id: string,
+  data: CategoryInterface
+): Promise<Document | null> => {
+  try {
+    const response = await updateCategoryRepository(id, data);
+    if (!response) throw new Error('Internal Server Error');
+    return response;
+  } catch (error) {
+    handleServiceError(error);
+    return null;
+  }
+};
+
+export default updateCategoryService;

--- a/TypeScript/Typescript Final Project/src/utils/errors/handle-repository-error.util.ts
+++ b/TypeScript/Typescript Final Project/src/utils/errors/handle-repository-error.util.ts
@@ -1,0 +1,6 @@
+const handleRepositoryError = (error: Error | any): void => {
+  if (error instanceof Error) throw new Error(error.message);
+  throw new Error('Database Failed To Create');
+};
+
+export default handleRepositoryError;

--- a/TypeScript/Typescript Final Project/src/utils/errors/handle-service-error.utils.ts
+++ b/TypeScript/Typescript Final Project/src/utils/errors/handle-service-error.utils.ts
@@ -1,0 +1,6 @@
+const handleServiceError = (error: Error | any): void => {
+  if (error instanceof Error) throw new Error(error.message);
+  throw new Error('An unknown error occurred in isBrandExistRepository.');
+};
+
+export default handleServiceError;


### PR DESCRIPTION
Created the following API endpoints for managing categories:
POST /categories: Allows creating a new category in the database.
GET /categories: Retrieves all categories from the database.
GET /categories/:id: Retrieves a single category by its id.
PUT /categories/:id: Updates an existing category by its id.
DELETE /categories/:id: Deletes a category by its id.
These endpoints enable full CRUD (Create, Read, Update, Delete) functionality for categories.
Ensured input validation and error handling for each endpoint to improve robustness.
Added corresponding controller functions and repository logic to interact with the database.